### PR TITLE
Add training template download links

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,15 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
       <div class="grid">
         <div class="card">
           <div class="toolbar" style="justify-content:space-between">
+            <strong>Training Templates</strong>
+          </div>
+          <div class="toolbar mt-3">
+            <a class="btn secondary" href="masterclass_ai_authoring_spec.txt" download>AI Authoring Spec</a>
+            <a class="btn secondary" href="masterclass_markdown_template.md" download>Markdown Template</a>
+          </div>
+        </div>
+        <div class="card">
+          <div class="toolbar" style="justify-content:space-between">
             <strong>Import</strong>
             <span class="badge">Paste Markdown or JSON • or drop a file</span>
           </div>


### PR DESCRIPTION
## Summary
- Add a Training Templates card to the main interface with download links for the AI authoring spec and Markdown template.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a0468e8083318a17b1f4a05eaad7