### PR TITLE
Add YouTube video slide template

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,7 @@ Subtitle
               <option>06_quote</option>
               <option>07_checklist</option>
               <option>08_conclusion</option>
+              <option>09_video</option>
             </select>
           </div>
           <div class="toolbar mt-3" style="justify-content:space-between">
@@ -236,7 +237,11 @@ function mdToOutline(md){
     if(/^###\s+/.test(L)){
       const h3 = L.replace(/^###\s+/, '').trim();
       const bullets = getList(i+1);
-      slides.push({ template:"04_two_col_bullets", data:{ h1:h3, subtitle:"", bullets, icon:"", caption:"" }});
+      if(bullets.length===1 && /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\//i.test(bullets[0])){
+        slides.push({ template:"09_video", data:{ h1:h3, youtube: bullets[0] }});
+      }else{
+        slides.push({ template:"04_two_col_bullets", data:{ h1:h3, subtitle:"", bullets, icon:"", caption:"" }});
+      }
       continue;
     }
   }
@@ -382,6 +387,17 @@ function slideHTML(s){
           </div>
         </div>
       ${end}`;
+    case "09_video": {
+      const m = (d.youtube||"").match(/(?:youtu.be\/|watch\?v=|embed\/)([^?&]+)/);
+      const id = m ? m[1] : "";
+      return `
+      ${begin}
+        <h1 class="hdr" style="font-size:32px;margin:0 0 12px">${d.h1||""}</h1>
+        <div class="center" style="height:540px">
+          <iframe width="800" height="450" src="${id?`https://www.youtube.com/embed/${id}`:""}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      ${end}`;
+    }
     default:
       return `${begin}<p class="p">Unknown template: ${s.template}</p>${end}`;
   }

--- a/masterclass_ai_authoring_spec.txt
+++ b/masterclass_ai_authoring_spec.txt
@@ -19,6 +19,7 @@ Rules (strict):
 6) Keep each bullet ≤ 100 characters. Plain text only.
 7) Do not include any prose paragraphs under H3 slides—only bullet lines starting with “- ”.
 8) Use blank lines between logical blocks. Avoid bold/italic/links – plain text is safest.
+9) To include a YouTube video slide, use an H3 heading with a single bullet containing the full YouTube URL.
 
 Example (you can copy this shape):
 
@@ -85,7 +86,8 @@ Rules (strict):
 
 3) Allowed template ids:
    "01_title", "02_toc", "03_section", "04_two_col_bullets",
-   "05_image_right_research", "06_quote", "07_checklist", "08_conclusion"
+   "05_image_right_research", "06_quote", "07_checklist", "08_conclusion",
+   "09_video"
 
 4) Field hints by template:
    • 01_title → data: { h1, subtitle }
@@ -96,6 +98,7 @@ Rules (strict):
    • 06_quote → data: { quote, by }
    • 07_checklist → data: { h1, items[] }
    • 08_conclusion → data: { h1, takeaways[], goal, steps[] }
+   • 09_video → data: { h1, youtube }
 
 Example minimal JSON:
 
@@ -106,7 +109,8 @@ Example minimal JSON:
     { "template": "02_toc", "data": { "h1": "Table of Contents", "items": ["Introduction","Roles","Inclusive Practices","Behavior","Data"] } },
     { "template": "03_section", "data": { "h1": "Introduction", "tagline": "Why this role matters" } },
     { "template": "04_two_col_bullets", "data": { "h1": "What Is a Paraprofessional?", "subtitle": "", "bullets": ["Supports teachers/students","Implements plans","Collects quick data"] } },
-    { "template": "06_quote", "data": { "quote": "Every interaction is an intervention.", "by": "Unknown" } }
+    { "template": "06_quote", "data": { "quote": "Every interaction is an intervention.", "by": "Unknown" } },
+    { "template": "09_video", "data": { "h1": "Watch this clip", "youtube": "https://youtu.be/dQw4w9WgXcQ" } }
   ]
 }
 

--- a/masterclass_markdown_template.md
+++ b/masterclass_markdown_template.md
@@ -28,6 +28,9 @@
 - [bullet 1]
 - [bullet 2]
 
+### [Video title]
+- https://www.youtube.com/watch?v=VIDEO_ID
+
 ## Section 4
 ### [Slide title]
 - [bullet 1]


### PR DESCRIPTION
## Summary
- add `09_video` template to embed YouTube videos in slides
- document video template in authoring spec and markdown template

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1bc738c83318308132519d9bd77