### PR TITLE
Fix TOC parser to capture full slide deck

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,7 +245,8 @@ function mdToOutline(md){
     }
 
     if(/^##\s+Table of Contents/i.test(L)){
-      const {items, next} = getList(i+1);
+      const items = getList(i+1);
+      const next = getList.next;
       slides.push({ template:"02_toc", data:{ h1:"Table of Contents", items }});
       i = next - 1;
       continue;


### PR DESCRIPTION
## Summary
- fix markdown parser so slides after Table of Contents are processed

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` shows 60 slides parsed

------
https://chatgpt.com/codex/tasks/task_e_68a12c22a8e48331b696ec621a9be46e