### PR TITLE
Add switchable slide color motifs with random option

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <style>
 :root{
   --bg:#0b1220; --card:#0f172a; --muted:#94a3b8; --text:#e2e8f0;
-  --brand:#2a4b8d; --accent:#e67e22; --paper:#f5f7ff;
+  --brand:#1e3a8a; --accent:#f97316; --paper:#f5f7ff;
 }
 *{box-sizing:border-box}
 html,body{height:100%}
@@ -42,13 +42,13 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 .slide-container{width:1280px;min-height:720px;position:relative;background:#fff;border-radius:12px;overflow:hidden}
 .title-bar{background:var(--brand);height:12px}
 .accent-bar{background:var(--accent);height:4px}
-.footer-bar{background:var(--brand);height:40px;color:white;display:flex;align-items:center;justify-content:space-between;padding:0 16px}
+.footer-bar{background:var(--brand);height:40px;color:white;display:flex;align-items:center;justify-content:space-between;padding:0 16px;font-weight:700}
 .icon-circle{width:80px;height:80px;border-radius:50%;background:#fff;border:2px solid var(--brand);display:flex;align-items:center;justify-content:center;font-size:36px}
 .section-icon{width:120px;height:120px;border-radius:50%;background:#fff;border:3px solid var(--brand);display:flex;align-items:center;justify-content:center;box-shadow:0 4px 6px rgba(0,0,0,.1);font-size:54px}
-.bullet-point{position:relative;padding-left:28px;margin:6px 0;font-size:18px;line-height:1.5}
+.bullet-point{position:relative;padding-left:28px;margin:6px 0;font-size:18px;line-height:1.5;font-weight:600;color:#1e293b}
 .bullet-point::before{content:"";position:absolute;left:0;top:10px;width:8px;height:8px;background:var(--brand);border-radius:50%}
-.hdr{font-family:Montserrat,Inter,sans-serif;color:#0b2250}
-.p{font-family:"Open Sans",Inter,sans-serif;color:#475569;line-height:1.5}
+.hdr{font-family:Montserrat,Inter,sans-serif;color:#0b1220;font-weight:700}
+.p{font-family:"Open Sans",Inter,sans-serif;color:#1e293b;line-height:1.5;font-weight:600}
 /* Utility-ish */
 .row{display:flex;gap:24px}
 .col{display:flex;flex-direction:column}
@@ -70,6 +70,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
     <header class="header">
       <div class="h1">Masterclass — one-file slide builder</div>
       <div class="toolbar">
+        <select id="themeSelect" class="input" style="width:auto"></select>
         <button class="btn" id="btnDownloadJson">Download outline.json</button>
         <button class="btn secondary" id="btnExportPPTX">Export PPTX</button>
         <button class="btn secondary" id="btnExportPDF">Export PDF</button>
@@ -192,7 +193,7 @@ Subtitle
 
 <script>
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
-let outline = { meta:{ title:"", presenter:"", org:"", date:"" }, slides:[] };
+let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
 
 function saveOutline(){
@@ -206,6 +207,24 @@ function loadOutline(){
   }
 }
 loadOutline();
+
+const themes = [
+  { name:"Royal Blue", brand:"#1e3a8a", accent:"#f97316" },
+  { name:"Forest Green", brand:"#15803d", accent:"#facc15" },
+  { name:"Purple Magenta", brand:"#6d28d9", accent:"#ec4899" },
+  { name:"Crimson Amber", brand:"#b91c1c", accent:"#f59e0b" },
+  { name:"Indigo Teal", brand:"#4338ca", accent:"#14b8a6" },
+  { name:"Rose Violet", brand:"#be123c", accent:"#a78bfa" },
+  { name:"Navy Coral", brand:"#1e293b", accent:"#fb7185" },
+  { name:"Emerald Peach", brand:"#047857", accent:"#fb923c" },
+  { name:"Slate Sky", brand:"#334155", accent:"#0ea5e9" },
+  { name:"Maroon Lime", brand:"#7f1d1d", accent:"#84cc16" },
+];
+
+function applyTheme(t){
+  document.documentElement.style.setProperty('--brand', t.brand);
+  document.documentElement.style.setProperty('--accent', t.accent);
+}
 
 function mdToOutline(md){
   const lines = md.split(/\r?\n/);
@@ -347,14 +366,14 @@ function slideHTML(s){
           <div class="col" style="flex:1">
             ${items.slice(0,half).map((t,i)=>`
               <div class="row" style="align-items:center;gap:8px">
-                <span class="icon-circle" style="width:32px;height:32px;font-size:14px;border-width:0;background:#1e3a8a;color:#fff">${i+1}</span>
+                <span class="icon-circle" style="width:32px;height:32px;font-size:14px;border-width:0;background:var(--brand);color:#fff">${i+1}</span>
                 <span class="p" style="font-weight:700">${t}</span>
               </div>`).join("")}
           </div>
           <div class="col" style="flex:1">
             ${items.slice(half).map((t,i)=>`
               <div class="row" style="align-items:center;gap:8px">
-                <span class="icon-circle" style="width:32px;height:32px;font-size:14px;border-width:0;background:#1e3a8a;color:#fff">${i+1+half}</span>
+                <span class="icon-circle" style="width:32px;height:32px;font-size:14px;border-width:0;background:var(--brand);color:#fff">${i+1+half}</span>
                 <span class="p" style="font-weight:700">${t}</span>
               </div>`).join("")}
           </div>
@@ -366,7 +385,7 @@ function slideHTML(s){
         <div class="row" style="align-items:center;height:540px">
           <div class="col" style="flex:2;padding-right:24px">
             <h1 class="hdr" style="font-size:60px;margin:0 0 12px">${d.h1||""}</h1>
-            <div style="width:120px;height:6px;background:#f59e0b;margin-bottom:12px"></div>
+            <div style="width:120px;height:6px;background:var(--accent);margin-bottom:12px"></div>
             <p class="p" style="font-size:22px;max-width:640px">${d.tagline||""}</p>
           </div>
           <div class="center" style="flex:1">
@@ -385,7 +404,7 @@ function slideHTML(s){
             ${(d.links||[]).map(l=>`<p class="p"><a data-href="${l.url}" href="${l.url}" target="_blank">${l.label}</a></p>`).join("")}
             ${d.video ? `<p class="p"><a data-href="${d.video}" href="${d.video}" target="_blank">Video ▶</a></p>`:""}
             ${d.highlight ? `
-              <div style="margin-top:12px;padding:12px;background:#eff6ff;border-left:4px solid #1e3a8a;border-radius:8px">
+              <div style="margin-top:12px;padding:12px;background:var(--paper);border-left:4px solid var(--brand);border-radius:8px">
                 <p class="hdr" style="font-size:18px;margin:0 0 6px">${d.highlight.title||"Key Consideration:"}</p>
                 <p class="p" style="margin:0">${d.highlight.text||""}</p>
               </div>` : ""}
@@ -407,7 +426,7 @@ function slideHTML(s){
             ${(d.bullets||[]).map(b=>`<p class="bullet-point">${b}</p>`).join("")}
             ${(d.links||[]).map(l=>`<p class="p"><a data-href="${l.url}" href="${l.url}" target="_blank">${l.label}</a></p>`).join("")}
             ${d.video ? `<p class="p"><a data-href="${d.video}" href="${d.video}" target="_blank">Video ▶</a></p>`:""}
-            <div style="margin-top:12px;padding:12px;background:#eff6ff;border-left:4px solid #1e3a8a;border-radius:8px">
+            <div style="margin-top:12px;padding:12px;background:var(--paper);border-left:4px solid var(--brand);border-radius:8px">
               <p class="hdr" style="font-size:18px;margin:0 0 6px">Research Shows:</p>
               <p class="p" style="margin:0">${d.research||""}</p>
             </div>
@@ -424,7 +443,7 @@ function slideHTML(s){
       ${begin}
         <div class="center" style="height:540px;text-align:center">
           <div style="max-width:900px">
-            <div class="hdr" style="font-size:28px;color:#1e3a8a">“</div>
+            <div class="hdr" style="font-size:28px;color:var(--brand)">“</div>
             <h2 class="hdr" style="font-size:38px;margin:0 0 8px">${d.quote||""}</h2>
             <p class="p">— ${d.by||"Unknown"}</p>
           </div>
@@ -459,7 +478,7 @@ function slideHTML(s){
         ${begin}
           <h1 class="hdr" style="font-size:32px;margin:0 0 8px">${d.h1||""}</h1>
           ${(d.bullets||[]).map(b=>`<p class="bullet-point">${b}</p>`).join("")}
-          ${d.table?`<table style="width:100%;border-collapse:collapse;margin-top:16px"><thead><tr>${(d.table.headers||[]).map(h=>`<th style="border:1px solid #94a3b8;padding:4px;background:#eff6ff">${h}</th>`).join("")}</tr></thead><tbody>${(d.table.rows||[]).map(r=>`<tr>${r.map(c=>`<td style="border:1px solid #94a3b8;padding:4px">${c}</td>`).join("")}</tr>`).join("")}</tbody></table>`:""}
+          ${d.table?`<table style="width:100%;border-collapse:collapse;margin-top:16px"><thead><tr>${(d.table.headers||[]).map(h=>`<th style="border:1px solid #94a3b8;padding:4px;background:var(--paper)">${h}</th>`).join("")}</tr></thead><tbody>${(d.table.rows||[]).map(r=>`<tr>${r.map(c=>`<td style="border:1px solid #94a3b8;padding:4px">${c}</td>`).join("")}</tr>`).join("")}</tbody></table>`:""}
         ${end}`;
       case "09_video": {
         const m = (d.youtube||"").match(/(?:youtu.be\/|watch\?v=|embed\/)([^?&]+)/);
@@ -503,12 +522,42 @@ const el = {
   btnDownloadJson: document.getElementById('btnDownloadJson'),
   btnExportPPTX: document.getElementById('btnExportPPTX'),
   btnExportPDF: document.getElementById('btnExportPDF'),
+  themeSelect: document.getElementById('themeSelect'),
   renderStage: document.getElementById('renderStage'),
+};
+
+themes.forEach((t,i)=>{
+  const opt = document.createElement('option');
+  opt.value = i;
+  opt.textContent = t.name;
+  el.themeSelect.appendChild(opt);
+});
+const optRandom = document.createElement('option');
+optRandom.value = 'random';
+optRandom.textContent = 'Random';
+el.themeSelect.appendChild(optRandom);
+
+if(outline.meta.theme == null) outline.meta.theme = 0;
+applyTheme(themes[outline.meta.theme]);
+el.themeSelect.value = outline.meta.theme;
+
+el.themeSelect.onchange = ()=>{
+  let val = el.themeSelect.value;
+  if(val === 'random'){
+    val = Math.floor(Math.random()*themes.length).toString();
+    el.themeSelect.value = val;
+  }
+  outline.meta.theme = parseInt(val,10);
+  applyTheme(themes[outline.meta.theme]);
+  saveOutline();
+  refreshUI();
 };
 
 function refreshUI(){
   if(!outline.meta) outline.meta = {};
   if(!Array.isArray(outline.slides)) outline.slides = [];
+  outline.meta.theme ??= 0;
+  el.themeSelect.value = outline.meta.theme;
   saveOutline();
   el.countBadge.textContent = `${outline.slides.length} items`;
   el.slideList.innerHTML = "";


### PR DESCRIPTION
## Summary
- allow choosing among 10 popular color motifs or a random palette for slide themes
- ensure all slide text is bold with dark colors on a white background for better readability
- wire slide templates to brand/accent variables so color motifs propagate through previews

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a139177f1c8331ad110999bc9ea3eb