### PR TITLE
feat: build PPTX slides from structured model

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,8 @@ Subtitle
     </div>
   </div>
 
-<script>
+<script type="module">
+import { buildPptx } from './src/export/pptxBuilder.js';
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
 let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
@@ -797,7 +798,8 @@ async function waitForImages(container){
     return new Promise(res=>{ img.onload = img.onerror = res; });
   }));
 }
-async function renderAllToImages(onProgress, opt={}){
+// Legacy screenshot renderer retained for PDF export
+async function renderSlidesToImages(onProgress, opt={}){
   // render slides into hidden stage and snapshot with html2canvas
   const stage = el.renderStage;
   stage.innerHTML = "";
@@ -835,25 +837,23 @@ async function renderAllToImages(onProgress, opt={}){
 el.btnExportPPTX.onclick = async ()=>{
   try {
     showProgress();
-    el.status.textContent = "⏳ Rendering slides…";
-    const lean = el.leanToggle.checked;
-    const imgs = await renderAllToImages(p=>setProgress(p*0.8), { lean });
     el.status.textContent = "⏳ Building PPTX…";
-    setProgress(90);
-    const pptx = new PptxGenJS();
-    pptx.layout = "LAYOUT_16x9";
-    imgs.forEach((img)=>{
-      const slide = pptx.addSlide();
-      slide.addImage({ data: img.src, x:0, y:0, w:10, h:5.625 });
-      (img.links||[]).forEach(l=>{
-        slide.addText('', { x:l.x/128, y:l.y/128, w:l.w/128, h:l.h/128, hyperlink:{ url:l.url }, color:'FFFFFF', fill:{ type:'solid', color:'FFFFFF', transparency:100 }, line:'FFFFFF', lineSize:0 });
-      });
-      if(img.notes && img.notes.length) slide.addNotes(img.notes.join('\n'));
+    setProgress(20);
+    const slides = outline.slides.map(s => {
+      const d = s.data || {};
+      const elements = [];
+      if (d.h1) elements.push({ type:'title', text:d.h1 });
+      if (d.subtitle) elements.push({ type:'text', text:d.subtitle });
+      if (Array.isArray(d.bullets)) d.bullets.forEach(b => elements.push({ type:'text', text:b }));
+      if (d.image) elements.push({ type:'image', src:d.image });
+      return { elements, notes: d.notes || [] };
     });
-    const name = (outline.meta.title || "Masterclass") + ".pptx";
+    const pptx = buildPptx(slides, { title: outline.meta.title });
+    setProgress(90);
     const blob = await pptx.write('blob');
     setProgress(100);
     hideProgress();
+    const name = (outline.meta.title || "Masterclass") + ".pptx";
     showDownload("PPTX ready", blob, name);
     el.status.textContent = "✅ PPTX ready";
   } catch(err){
@@ -869,7 +869,7 @@ el.btnExportPDF.onclick = async ()=>{
     showProgress();
     el.status.textContent = "⏳ Rendering slides…";
     const lean = el.leanToggle.checked;
-    const imgs = await renderAllToImages(p=>setProgress(p*0.8), { lean });
+    const imgs = await renderSlidesToImages(p=>setProgress(p*0.8), { lean });
     el.status.textContent = "⏳ Building PDF…";
     setProgress(90);
     const { jsPDF } = window.jspdf;

--- a/src/export/pptxBuilder.js
+++ b/src/export/pptxBuilder.js
@@ -1,0 +1,36 @@
+/**
+ * Build a PPTX presentation from a structured slide model.
+ */
+export function buildPptx(slides, meta = {}) {
+  const pptx = new PptxGenJS();
+  pptx.layout = 'LAYOUT_16x9';
+  if (meta.title) {
+    pptx.coreProps = { title: meta.title };
+  }
+
+  slides.forEach(slideModel => {
+    const slide = pptx.addSlide();
+    let y = 0.5;
+    slideModel.elements.forEach(el => {
+      switch (el.type) {
+        case 'title':
+          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
+          y += 1;
+          break;
+        case 'text':
+          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+          y += 0.6;
+          break;
+        case 'image':
+          slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
+          y += 3.5;
+          break;
+      }
+    });
+    if (slideModel.notes && slideModel.notes.length) {
+      slide.addNotes(slideModel.notes.join('\n'));
+    }
+  });
+
+  return pptx;
+}

--- a/src/export/pptxBuilder.ts
+++ b/src/export/pptxBuilder.ts
@@ -1,0 +1,57 @@
+/**
+ * Build a PPTX presentation from a structured slide model.
+ */
+
+export interface SlideElement {
+  type: 'title' | 'text' | 'image';
+  text?: string;
+  src?: string;
+  options?: any;
+}
+
+export interface SlideModel {
+  elements: SlideElement[];
+  notes?: string[];
+}
+
+// PptxGenJS is loaded globally via <script>
+declare const PptxGenJS: any;
+
+/**
+ * Convert an array of slide models into a PptxGenJS presentation.
+ * @param slides Array of slide definitions
+ * @param meta Optional metadata such as title
+ */
+export function buildPptx(slides: SlideModel[], meta: { title?: string } = {}): any {
+  const pptx = new PptxGenJS();
+  pptx.layout = 'LAYOUT_16x9';
+  if (meta.title) {
+    pptx.coreProps = { title: meta.title };
+  }
+
+  slides.forEach(slideModel => {
+    const slide = pptx.addSlide();
+    let y = 0.5;
+    slideModel.elements.forEach(el => {
+      switch (el.type) {
+        case 'title':
+          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
+          y += 1;
+          break;
+        case 'text':
+          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+          y += 0.6;
+          break;
+        case 'image':
+          slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
+          y += 3.5;
+          break;
+      }
+    });
+    if (slideModel.notes && slideModel.notes.length) {
+      slide.addNotes(slideModel.notes.join('\n'));
+    }
+  });
+
+  return pptx;
+}


### PR DESCRIPTION
## Summary
- add pptxBuilder module to map slide elements to PptxGenJS
- use builder in export flow instead of html2canvas screenshots
- mark screenshot renderer as legacy for PDF only

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a14a0109d48331bc8bd82195ec5c67