### PR TITLE
Render slides to images for PPTX export

### DIFF
--- a/index.html
+++ b/index.html
@@ -837,19 +837,13 @@ async function renderSlidesToImages(onProgress, opt={}){
 el.btnExportPPTX.onclick = async ()=>{
   try {
     showProgress();
+    el.status.textContent = "⏳ Rendering slides…";
+    const lean = el.leanToggle.checked;
+    const imgs = await renderSlidesToImages(p=>setProgress(p*0.8), { lean });
     el.status.textContent = "⏳ Building PPTX…";
-    setProgress(20);
-    const slides = outline.slides.map(s => {
-      const d = s.data || {};
-      const elements = [];
-      if (d.h1) elements.push({ type:'title', text:d.h1 });
-      if (d.subtitle) elements.push({ type:'text', text:d.subtitle });
-      if (Array.isArray(d.bullets)) d.bullets.forEach(b => elements.push({ type:'text', text:b }));
-      if (d.image) elements.push({ type:'image', src:d.image });
-      return { elements, notes: d.notes || [] };
-    });
-    const pptx = buildPptx(slides, { title: outline.meta.title });
     setProgress(90);
+    const slides = imgs.map(img => ({ src: img.src, notes: img.notes }));
+    const pptx = buildPptx(slides, { title: outline.meta.title });
     const blob = await pptx.write('blob');
     setProgress(100);
     hideProgress();

--- a/src/export/pptxBuilder.js
+++ b/src/export/pptxBuilder.js
@@ -10,23 +10,28 @@ export function buildPptx(slides, meta = {}) {
 
   slides.forEach(slideModel => {
     const slide = pptx.addSlide();
-    let y = 0.5;
-    slideModel.elements.forEach(el => {
-      switch (el.type) {
-        case 'title':
-          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
-          y += 1;
-          break;
-        case 'text':
-          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
-          y += 0.6;
-          break;
-        case 'image':
-          slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
-          y += 3.5;
-          break;
-      }
-    });
+    if (slideModel.src) {
+      // Slide represented as a pre-rendered image
+      slide.addImage({ data: slideModel.src, x: 0, y: 0, w: 10, h: 5.625 });
+    } else if (slideModel.elements) {
+      let y = 0.5;
+      slideModel.elements.forEach(el => {
+        switch (el.type) {
+          case 'title':
+            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
+            y += 1;
+            break;
+          case 'text':
+            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+            y += 0.6;
+            break;
+          case 'image':
+            slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
+            y += 3.5;
+            break;
+        }
+      });
+    }
     if (slideModel.notes && slideModel.notes.length) {
       slide.addNotes(slideModel.notes.join('\n'));
     }

--- a/src/export/pptxBuilder.ts
+++ b/src/export/pptxBuilder.ts
@@ -9,8 +9,10 @@ export interface SlideElement {
   options?: any;
 }
 
+// A slide can be a list of structured elements or a pre-rendered image
 export interface SlideModel {
-  elements: SlideElement[];
+  elements?: SlideElement[];
+  src?: string; // data URL of a rendered slide image
   notes?: string[];
 }
 
@@ -31,23 +33,28 @@ export function buildPptx(slides: SlideModel[], meta: { title?: string } = {}): 
 
   slides.forEach(slideModel => {
     const slide = pptx.addSlide();
-    let y = 0.5;
-    slideModel.elements.forEach(el => {
-      switch (el.type) {
-        case 'title':
-          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
-          y += 1;
-          break;
-        case 'text':
-          slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
-          y += 0.6;
-          break;
-        case 'image':
-          slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
-          y += 3.5;
-          break;
-      }
-    });
+    if (slideModel.src) {
+      // slide provided as a full-size image (e.g., html2canvas render)
+      slide.addImage({ data: slideModel.src, x: 0, y: 0, w: 10, h: 5.625 });
+    } else if (slideModel.elements) {
+      let y = 0.5;
+      slideModel.elements.forEach(el => {
+        switch (el.type) {
+          case 'title':
+            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
+            y += 1;
+            break;
+          case 'text':
+            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+            y += 0.6;
+            break;
+          case 'image':
+            slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
+            y += 3.5;
+            break;
+        }
+      });
+    }
     if (slideModel.notes && slideModel.notes.length) {
       slide.addNotes(slideModel.notes.join('\n'));
     }


### PR DESCRIPTION
## Summary
- Render slides to images and embed them into the PPTX for export
- Allow `pptxBuilder` to accept pre-rendered slide images alongside structured elements

## Testing
- `node --check src/export/pptxBuilder.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a14d065cc883318fecab3a7dbd9553