### PR TITLE
fix pptx export failure by using updated pptxgenjs write api

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,7 +844,7 @@ el.btnExportPPTX.onclick = async ()=>{
     setProgress(90);
     const slides = imgs.map(img => ({ src: img.src, notes: img.notes }));
     const pptx = buildPptx(slides, { title: outline.meta.title });
-    const blob = await pptx.write('blob');
+    const blob = await pptx.write({ outputType: 'blob' });
     setProgress(100);
     hideProgress();
     const name = (outline.meta.title || "Masterclass") + ".pptx";


### PR DESCRIPTION
## Summary
- fix PPTX export by calling `pptx.write({ outputType: 'blob' })` to match current PptxGenJS API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1504a378083319eeabdf8b25c50ce