### PR TITLE
Add ODP export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Masterclass — Research → Slides → PPTX/PDF</title>
+<title>Masterclass — Research → Slides → PPTX/ODP/PDF</title>
 
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -80,6 +80,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 <!-- Client-side exporters -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 </head>
 <body>
@@ -91,6 +92,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
         <button class="btn" id="btnDownloadJson">Download outline.json</button>
         <label class="small" style="display:flex;align-items:center;gap:4px"><input type="checkbox" id="leanToggle" checked/> Lean export</label>
         <button class="btn secondary" id="btnExportPPTX">Export PPTX</button>
+        <button class="btn secondary" id="btnExportODP">Export ODP</button>
         <button class="btn secondary" id="btnExportPDF">Export PDF</button>
         <div id="progressWrap" class="progress hidden"><div id="progressBar" class="progress-bar"></div></div>
       </div>
@@ -102,7 +104,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
         <li>Download the <a href="masterclass_markdown_template.md" download>Markdown Template</a>.</li>
         <li>Load it into your AI tool and prompt: <span class="small">"Research the topic and fill the template using markdown. Include image placeholders like <code>![](url)</code> and video links."</span></li>
         <li>Paste the AI's markdown below and click <strong>Use Pasted Text</strong>.</li>
-        <li>Review the slides, then export to PPTX or PDF.</li>
+        <li>Review the slides, then export to PPTX, ODP or PDF.</li>
       </ol>
     </div>
 
@@ -218,6 +220,7 @@ Subtitle
 
 <script type="module">
 import { buildPptx } from './src/export/pptxBuilder.js';
+import { buildOdp } from './src/export/odpBuilder.js';
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
 let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
@@ -574,6 +577,7 @@ const el = {
   metaDate: document.getElementById('metaDate'),
   btnDownloadJson: document.getElementById('btnDownloadJson'),
   btnExportPPTX: document.getElementById('btnExportPPTX'),
+  btnExportODP: document.getElementById('btnExportODP'),
   btnExportPDF: document.getElementById('btnExportPDF'),
   leanToggle: document.getElementById('leanToggle'),
   themeSelect: document.getElementById('themeSelect'),
@@ -854,6 +858,29 @@ el.btnExportPPTX.onclick = async ()=>{
     console.error('Failed to export PPTX', err);
     hideProgress();
     el.status.textContent = "❌ PPTX export failed";
+  }
+};
+
+/*** --------------------- EXPORT: ODP --------------------- ***/
+el.btnExportODP.onclick = async ()=>{
+  try {
+    showProgress();
+    el.status.textContent = "⏳ Rendering slides…";
+    const lean = el.leanToggle.checked;
+    const imgs = await renderSlidesToImages(p=>setProgress(p*0.8), { lean });
+    el.status.textContent = "⏳ Building ODP…";
+    setProgress(90);
+    const slides = imgs.map(img => ({ src: img.src, notes: img.notes }));
+    const blob = await buildOdp(slides, { title: outline.meta.title });
+    setProgress(100);
+    hideProgress();
+    const name = (outline.meta.title || "Masterclass") + ".odp";
+    showDownload("ODP ready", blob, name);
+    el.status.textContent = "✅ ODP ready";
+  } catch(err){
+    console.error('Failed to export ODP', err);
+    hideProgress();
+    el.status.textContent = "❌ ODP export failed";
   }
 };
 

--- a/src/export/odpBuilder.js
+++ b/src/export/odpBuilder.js
@@ -1,0 +1,38 @@
+/**
+ * Build an ODP presentation from slide images.
+ */
+export async function buildOdp(slides, meta = {}) {
+  const zip = new JSZip();
+  // The mimetype file must be stored with no compression
+  zip.file('mimetype', 'application/vnd.oasis.opendocument.presentation', { compression: 'STORE' });
+
+  const manifest = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">',
+    '<manifest:file-entry manifest:full-path="/" manifest:version="1.2" manifest:media-type="application/vnd.oasis.opendocument.presentation"/>',
+    '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>'
+  ];
+
+  const content = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.2">',
+    '<office:body><office:presentation>'
+  ];
+
+  slides.forEach((s, i) => {
+    const idx = i + 1;
+    const imgName = `Pictures/slide${idx}.png`;
+    manifest.push(`<manifest:file-entry manifest:full-path="${imgName}" manifest:media-type="image/png"/>`);
+    content.push(`<draw:page draw:name="page${idx}"><draw:frame svg:x="0cm" svg:y="0cm" svg:width="28cm" svg:height="21cm"><draw:image xlink:href="${imgName}" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/></draw:frame></draw:page>`);
+    const base64 = s.src.split(',')[1];
+    zip.file(imgName, base64, { base64: true });
+  });
+
+  content.push('</office:presentation></office:body></office:document-content>');
+  manifest.push('</manifest:manifest>');
+
+  zip.file('content.xml', content.join(''));
+  zip.file('META-INF/manifest.xml', manifest.join(''));
+
+  return zip.generateAsync({ type: 'blob' });
+}

--- a/src/export/odpBuilder.ts
+++ b/src/export/odpBuilder.ts
@@ -1,0 +1,47 @@
+/**
+ * Build an ODP presentation from slide images.
+ */
+
+export interface SlideModel {
+  src: string; // data URL of slide image
+  notes?: string[];
+}
+
+// JSZip is loaded globally via <script>
+declare const JSZip: any;
+
+export async function buildOdp(slides: SlideModel[], meta: { title?: string } = {}): Promise<Blob> {
+  const zip = new JSZip();
+  // The mimetype file must be stored with no compression
+  zip.file('mimetype', 'application/vnd.oasis.opendocument.presentation', { compression: 'STORE' });
+
+  const manifest: string[] = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">',
+    '<manifest:file-entry manifest:full-path="/" manifest:version="1.2" manifest:media-type="application/vnd.oasis.opendocument.presentation"/>',
+    '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>'
+  ];
+
+  const content: string[] = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.2">',
+    '<office:body><office:presentation>'
+  ];
+
+  slides.forEach((s, i) => {
+    const idx = i + 1;
+    const imgName = `Pictures/slide${idx}.png`;
+    manifest.push(`<manifest:file-entry manifest:full-path="${imgName}" manifest:media-type="image/png"/>`);
+    content.push(`<draw:page draw:name="page${idx}"><draw:frame svg:x="0cm" svg:y="0cm" svg:width="28cm" svg:height="21cm"><draw:image xlink:href="${imgName}" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/></draw:frame></draw:page>`);
+    const base64 = s.src.split(',')[1];
+    zip.file(imgName, base64, { base64: true });
+  });
+
+  content.push('</office:presentation></office:body></office:document-content>');
+  manifest.push('</manifest:manifest>');
+
+  zip.file('content.xml', content.join(''));
+  zip.file('META-INF/manifest.xml', manifest.join(''));
+
+  return zip.generateAsync({ type: 'blob' });
+}


### PR DESCRIPTION
## Summary
- add JSZip and new ODP export button to UI
- implement ODP builder that packages slide images into an ODP file
- wire up ODP download flow alongside existing PPTX/PDF exports

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const fs=require('fs'); let code=fs.readFileSync('./src/export/odpBuilder.js','utf8').replace('export async function buildOdp','async function buildOdp'); global.JSZip=require('jszip'); eval(code); const base64='iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4DwQACfsD/Q2Fo4AAAAAASUVORK5CYII='; buildOdp([{src:'data:image/png;base64,'+base64}]).then(b=>console.log('ODP bytes', b.size));"`

------
https://chatgpt.com/codex/tasks/task_e_68a1546961c883319ef6973cb646eff5