### PR TITLE
Add ODS export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>Masterclass — Research → Slides → PPTX/ODP/PDF</title>
+<title>Masterclass — Research → Slides → PPTX/ODS/PDF</title>
 
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -92,7 +92,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
         <button class="btn" id="btnDownloadJson">Download outline.json</button>
         <label class="small" style="display:flex;align-items:center;gap:4px"><input type="checkbox" id="leanToggle" checked/> Lean export</label>
         <button class="btn secondary" id="btnExportPPTX">Export PPTX</button>
-        <button class="btn secondary" id="btnExportODP">Export ODP</button>
+        <button class="btn secondary" id="btnExportODS">Export ODS</button>
         <button class="btn secondary" id="btnExportPDF">Export PDF</button>
         <div id="progressWrap" class="progress hidden"><div id="progressBar" class="progress-bar"></div></div>
       </div>
@@ -104,7 +104,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
         <li>Download the <a href="masterclass_markdown_template.md" download>Markdown Template</a>.</li>
         <li>Load it into your AI tool and prompt: <span class="small">"Research the topic and fill the template using markdown. Include image placeholders like <code>![](url)</code> and video links."</span></li>
         <li>Paste the AI's markdown below and click <strong>Use Pasted Text</strong>.</li>
-        <li>Review the slides, then export to PPTX, ODP or PDF.</li>
+        <li>Review the slides, then export to PPTX, ODS or PDF.</li>
       </ol>
     </div>
 
@@ -220,7 +220,7 @@ Subtitle
 
 <script type="module">
 import { buildPptx } from './src/export/pptxBuilder.js';
-import { buildOdp } from './src/export/odpBuilder.js';
+import { buildOds } from './src/export/odsBuilder.js';
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
 let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
@@ -577,7 +577,7 @@ const el = {
   metaDate: document.getElementById('metaDate'),
   btnDownloadJson: document.getElementById('btnDownloadJson'),
   btnExportPPTX: document.getElementById('btnExportPPTX'),
-  btnExportODP: document.getElementById('btnExportODP'),
+  btnExportODS: document.getElementById('btnExportODS'),
   btnExportPDF: document.getElementById('btnExportPDF'),
   leanToggle: document.getElementById('leanToggle'),
   themeSelect: document.getElementById('themeSelect'),
@@ -861,26 +861,26 @@ el.btnExportPPTX.onclick = async ()=>{
   }
 };
 
-/*** --------------------- EXPORT: ODP --------------------- ***/
-el.btnExportODP.onclick = async ()=>{
+/*** --------------------- EXPORT: ODS --------------------- ***/
+el.btnExportODS.onclick = async ()=>{
   try {
     showProgress();
     el.status.textContent = "⏳ Rendering slides…";
     const lean = el.leanToggle.checked;
     const imgs = await renderSlidesToImages(p=>setProgress(p*0.8), { lean });
-    el.status.textContent = "⏳ Building ODP…";
+    el.status.textContent = "⏳ Building ODS…";
     setProgress(90);
     const slides = imgs.map(img => ({ src: img.src, notes: img.notes }));
-    const blob = await buildOdp(slides, { title: outline.meta.title });
+    const blob = await buildOds(slides, { title: outline.meta.title });
     setProgress(100);
     hideProgress();
-    const name = (outline.meta.title || "Masterclass") + ".odp";
-    showDownload("ODP ready", blob, name);
-    el.status.textContent = "✅ ODP ready";
+    const name = (outline.meta.title || "Masterclass") + ".ods";
+    showDownload("ODS ready", blob, name);
+    el.status.textContent = "✅ ODS ready";
   } catch(err){
-    console.error('Failed to export ODP', err);
+    console.error('Failed to export ODS', err);
     hideProgress();
-    el.status.textContent = "❌ ODP export failed";
+    el.status.textContent = "❌ ODS export failed";
   }
 };
 

--- a/src/export/odsBuilder.js
+++ b/src/export/odsBuilder.js
@@ -1,0 +1,34 @@
+export async function buildOds(slides, meta = {}) {
+  const zip = new JSZip();
+  zip.file('mimetype', 'application/vnd.oasis.opendocument.spreadsheet', { compression: 'STORE' });
+
+  const manifest = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">',
+    '<manifest:file-entry manifest:full-path="/" manifest:version="1.2" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>',
+    '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>'
+  ];
+
+  const content = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.2">',
+    '<office:body><office:spreadsheet>'
+  ];
+
+  slides.forEach((s, i) => {
+    const idx = i + 1;
+    const imgName = `Pictures/slide${idx}.png`;
+    manifest.push(`<manifest:file-entry manifest:full-path="${imgName}" manifest:media-type="image/png"/>`);
+    content.push(`<table:table table:name="Sheet${idx}"><table:table-row><table:table-cell><text:p/></table:table-cell></table:table-row><table:shapes><draw:frame draw:name="frame${idx}" svg:x="0cm" svg:y="0cm" svg:width="28cm" svg:height="21cm"><draw:image xlink:href="${imgName}" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/></draw:frame></table:shapes></table:table>`);
+    const base64 = s.src.split(',')[1];
+    zip.file(imgName, base64, { base64: true });
+  });
+
+  content.push('</office:spreadsheet></office:body></office:document-content>');
+  manifest.push('</manifest:manifest>');
+
+  zip.file('content.xml', content.join(''));
+  zip.file('META-INF/manifest.xml', manifest.join(''));
+
+  return zip.generateAsync({ type: 'blob' });
+}

--- a/src/export/odsBuilder.ts
+++ b/src/export/odsBuilder.ts
@@ -1,0 +1,47 @@
+/**
+ * Build an ODS spreadsheet from slide images.
+ */
+
+export interface SlideModel {
+  src: string; // data URL of slide image
+  notes?: string[];
+}
+
+// JSZip is loaded globally via <script>
+declare const JSZip: any;
+
+export async function buildOds(slides: SlideModel[], meta: { title?: string } = {}): Promise<Blob> {
+  const zip = new JSZip();
+  // The mimetype file must be stored with no compression
+  zip.file('mimetype', 'application/vnd.oasis.opendocument.spreadsheet', { compression: 'STORE' });
+
+  const manifest: string[] = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">',
+    '<manifest:file-entry manifest:full-path="/" manifest:version="1.2" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>',
+    '<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/>'
+  ];
+
+  const content: string[] = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.2">',
+    '<office:body><office:spreadsheet>'
+  ];
+
+  slides.forEach((s, i) => {
+    const idx = i + 1;
+    const imgName = `Pictures/slide${idx}.png`;
+    manifest.push(`<manifest:file-entry manifest:full-path="${imgName}" manifest:media-type="image/png"/>`);
+    content.push(`<table:table table:name="Sheet${idx}"><table:table-row><table:table-cell><text:p/></table:table-cell></table:table-row><table:shapes><draw:frame draw:name="frame${idx}" svg:x="0cm" svg:y="0cm" svg:width="28cm" svg:height="21cm"><draw:image xlink:href="${imgName}" xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/></draw:frame></table:shapes></table:table>`);
+    const base64 = s.src.split(',')[1];
+    zip.file(imgName, base64, { base64: true });
+  });
+
+  content.push('</office:spreadsheet></office:body></office:document-content>');
+  manifest.push('</manifest:manifest>');
+
+  zip.file('content.xml', content.join(''));
+  zip.file('META-INF/manifest.xml', manifest.join(''));
+
+  return zip.generateAsync({ type: 'blob' });
+}


### PR DESCRIPTION
## Summary
- add new ODS builder to create OpenDocument spreadsheets from slide images
- replace ODP export with ODS in the UI and download workflow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a15817bb1c83318621af47895e03e4