### PR TITLE
Correct ODS and PPTX export MIME types

### DIFF
--- a/index.html
+++ b/index.html
@@ -848,7 +848,10 @@ el.btnExportPPTX.onclick = async ()=>{
     setProgress(90);
     const slides = imgs.map(img => ({ src: img.src, notes: img.notes }));
     const pptx = buildPptx(slides, { title: outline.meta.title });
-    const blob = await pptx.write({ outputType: 'blob' });
+    const pptxBlob = await pptx.write('blob');
+    const blob = new Blob([pptxBlob], {
+      type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+    });
     setProgress(100);
     hideProgress();
     const name = (outline.meta.title || "Masterclass") + ".pptx";

--- a/src/export/odsBuilder.js
+++ b/src/export/odsBuilder.js
@@ -30,5 +30,5 @@ export async function buildOds(slides, meta = {}) {
   zip.file('content.xml', content.join(''));
   zip.file('META-INF/manifest.xml', manifest.join(''));
 
-  return zip.generateAsync({ type: 'blob' });
+  return zip.generateAsync({ type: 'blob', mimeType: 'application/vnd.oasis.opendocument.spreadsheet' });
 }

--- a/src/export/odsBuilder.ts
+++ b/src/export/odsBuilder.ts
@@ -43,5 +43,8 @@ export async function buildOds(slides: SlideModel[], meta: { title?: string } = 
   zip.file('content.xml', content.join(''));
   zip.file('META-INF/manifest.xml', manifest.join(''));
 
-  return zip.generateAsync({ type: 'blob' });
+  return zip.generateAsync({
+    type: 'blob',
+    mimeType: 'application/vnd.oasis.opendocument.spreadsheet'
+  });
 }


### PR DESCRIPTION
## Summary
- ensure ODS builder outputs blob with `application/vnd.oasis.opendocument.spreadsheet`
- generate PPTX blob and rewrap to use official PowerPoint MIME type

## Testing
- `node --input-type=module -e "globalThis.JSZip=(await import('jszip')).default; const {buildOds}=await import('./src/export/odsBuilder.js'); const slides=[{src:'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='}]; const blob=await buildOds(slides,{}); console.log('mime',blob.type,'size',blob.size);"`
- `node --input-type=module -e "globalThis.PptxGenJS=(await import('pptxgenjs')).default; const {buildPptx}=await import('./src/export/pptxBuilder.js'); const pptx=buildPptx([{src:'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='}]); const pptxBlob=await pptx.write('blob'); const blob=new Blob([pptxBlob], {type:'application/vnd.openxmlformats-officedocument.presentationml.presentation'}); console.log('mime',blob.type,'size',blob.size);"`
- `npm test` (fails: Error: no test specified)`

------
https://chatgpt.com/codex/tasks/task_e_68a159f3434883319dfb474888157576