### PR TITLE
Fix PPTX library loading order

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 
 <!-- Client-side exporters -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pptxgenjs@3.12.0/dist/pptxgen.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Fix error when exporting PPTX by loading JSZip before pptxgenjs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ea41f4448331b6aabb91891a8f53