### PR TITLE
Preserve text in PPTX export

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,7 @@ Subtitle
 
 <script type="module">
 import { buildOdp } from './src/export/odpBuilder.js';
+import { buildPptx } from './src/export/pptxBuilder.js';
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
 let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
@@ -866,38 +867,61 @@ async function renderAllToImages(opt={}){
   return { images, hotspotsBySlide };
 }
 
+function outlineToPptxSlides(outline){
+  const slides = [];
+  const fallback = [];
+  outline.slides.forEach((s,i)=>{
+    const d = s.data || {};
+    const notes = d.notes || [];
+    switch(s.template){
+      case "01_title":
+        slides[i] = { elements:[
+          { type:"title", text:d.h1 || "" },
+          ...(d.subtitle?[{ type:"text", text:d.subtitle, options:{ fontSize:24 } }]:[])
+        ], notes };
+        break;
+      case "02_toc":
+        slides[i] = { elements:[
+          { type:"title", text:d.h1 || "Table of Contents" },
+          ...(d.items && d.items.length ? [{ type:"text", text:d.items.join("\n"), options:{ bullet:true } }] : [])
+        ], notes };
+        break;
+      case "03_section":
+        slides[i] = { elements:[
+          { type:"title", text:d.h1 || "" },
+          ...(d.tagline?[{ type:"text", text:d.tagline }]:[])
+        ], notes };
+        break;
+      case "04_two_col_bullets":
+        if(d.image || d.table || d.video){
+          fallback.push(i);
+          slides[i] = null;
+        }else{
+          slides[i] = { elements:[
+            { type:"title", text:d.h1 || "" },
+            ...(d.bullets && d.bullets.length ? [{ type:"text", text:d.bullets.join("\n"), options:{ bullet:true } }] : [])
+          ], notes };
+        }
+        break;
+      default:
+        fallback.push(i);
+        slides[i] = null;
+    }
+  });
+  return { slides, fallback };
+}
+
 el.btnExportPPTX.onclick = async ()=>{
   try{
-    el.status.textContent = "⏳ Rendering slides…";
-    const { images, hotspotsBySlide } = await renderAllToImages({ lean: el.leanToggle.checked });
-
-    const PptxCtor = window.PptxGenJS?.default || window.PptxGenJS;
-    if (!PptxCtor) {
-      alert("PPTX library not loaded. Check the <script> tag for pptxgenjs.");
-      return;
+    const { slides, fallback } = outlineToPptxSlides(outline);
+    let images = [];
+    if(fallback.length){
+      el.status.textContent = "⏳ Rendering slides…";
+      ({ images } = await renderAllToImages({ lean: el.leanToggle.checked }));
+      fallback.forEach(i=>{ slides[i] = { src: images[i], notes: outline.slides[i].data.notes || [] }; });
     }
-
     el.status.textContent = "⏳ Building PPTX…";
-    const pptx = new PptxCtor();
-    pptx.layout = "LAYOUT_16x9";
-
-    const pxToInX = px => (px/1280)*10;
-    const pxToInY = px => (px/720)*5.625;
-
-    images.forEach((src,i)=>{
-      const slide = pptx.addSlide();
-      slide.addImage({ data: src, x: 0, y: 0, w: 10, h: 5.625 });
-      (hotspotsBySlide[i]||[]).forEach(h=>{
-        slide.addText(" ",{
-          x:pxToInX(h.x), y:pxToInY(h.y),
-          w:pxToInX(h.w), h:pxToInY(h.h),
-          hyperlink:{ url:h.url },
-          fill:{ color:"FFFFFF", transparency:100 },
-          line:{ color:"FFFFFF", transparency:100 }
-        });
-      });
-    });
-
+    const pptx = buildPptx(slides, { title: outline.meta.title });
     const name = (outline.meta.title || "Masterclass") + ".pptx";
     await pptx.writeFile({ fileName: name });
     el.status.textContent = "✅ PPTX saved";

--- a/src/export/pptxBuilder.js
+++ b/src/export/pptxBuilder.js
@@ -21,10 +21,13 @@ export function buildPptx(slides, meta = {}) {
             slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
             y += 1;
             break;
-          case 'text':
-            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
-            y += 0.6;
+          case 'text': {
+            const text = el.text || '';
+            slide.addText(text, { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+            const lines = text.split('\n').length;
+            y += 0.6 * lines;
             break;
+          }
           case 'image':
             slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
             y += 3.5;

--- a/src/export/pptxBuilder.ts
+++ b/src/export/pptxBuilder.ts
@@ -44,10 +44,13 @@ export function buildPptx(slides: SlideModel[], meta: { title?: string } = {}): 
             slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 32, bold: true, ...(el.options || {}) });
             y += 1;
             break;
-          case 'text':
-            slide.addText(el.text || '', { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
-            y += 0.6;
+          case 'text': {
+            const text = el.text || '';
+            slide.addText(text, { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
+            const lines = text.split('\n').length;
+            y += 0.6 * lines;
             break;
+          }
           case 'image':
             slide.addImage({ path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) });
             y += 3.5;


### PR DESCRIPTION
## Summary
- generate PPTX slides using structured text rather than full-slide images
- convert outline data to slide models and fall back to images when needed
- account for multi-line text spacing in PPTX builder

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f2ffb7ec83318183187033d0464e