### PR TITLE
Add highlight callout card support and PPTX progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,10 @@ function mdToOutline(md){
             const rest = b.replace(/^IMG:\s*/i, '').trim();
             const [url,cap] = rest.split(/\s*\|\s*/);
             if(url){ data.image = url; if(cap) data.caption = cap; }
+          }else if(/^HIGHLIGHT:/i.test(b)){
+            const rest = b.replace(/^HIGHLIGHT:\s*/i, '').trim();
+            const [title,text] = rest.split(/\s*\|\s*/);
+            data.highlight = { title: title || 'Key Consideration:', text: text || '' };
           }else{
             data.bullets.push(b);
           }
@@ -868,16 +872,19 @@ async function renderAllToImages(opt={}){
 
 el.btnExportPPTX.onclick = async ()=>{
   try{
+    showProgress();
     el.status.textContent = "⏳ Rendering slides…";
     const { images, hotspotsBySlide } = await renderAllToImages({ lean: el.leanToggle.checked });
 
+    el.status.textContent = "⏳ Building PPTX…";
+    setProgress(90);
     const PptxCtor = window.PptxGenJS?.default || window.PptxGenJS;
     if (!PptxCtor) {
       alert("PPTX library not loaded. Check the <script> tag for pptxgenjs.");
+      hideProgress();
       return;
     }
 
-    el.status.textContent = "⏳ Building PPTX…";
     const pptx = new PptxCtor();
     pptx.layout = "LAYOUT_16x9";
 
@@ -900,9 +907,12 @@ el.btnExportPPTX.onclick = async ()=>{
 
     const name = (outline.meta.title || "Masterclass") + ".pptx";
     await pptx.writeFile({ fileName: name });
+    setProgress(100);
+    hideProgress();
     el.status.textContent = "✅ PPTX saved";
   }catch(err){
     console.error(err);
+    hideProgress();
     alert("PPTX export failed. Open the console for details.");
     el.status.textContent = "❌ PPTX export failed";
   }

--- a/masterclass_ai_authoring_spec.txt
+++ b/masterclass_ai_authoring_spec.txt
@@ -25,8 +25,9 @@ Rules (strict):
 12) LINK: Under any ### slide, add LINK: Label | https://...
 13) IMG (optional): IMG: https://... | optional caption (shows right-side image).
 14) TABLE (optional): Start a bullet with TABLE: then provide Markdown table rows on subsequent lines. First row is headers.
-15) Bullets may include emojis for emphasis.
-16) Continue the pattern for as many slides as needed; no slide limit.
+15) HIGHLIGHT (optional): HIGHLIGHT: Title | text (adds a callout card for key ideas, e.g., "Research shows | statistic" or "Best Practice | tip").
+16) Bullets may include emojis for emphasis.
+17) Continue the pattern for as many slides as needed; no slide limit.
 
 Example (you can copy this shape):
 

--- a/masterclass_markdown_template.md
+++ b/masterclass_markdown_template.md
@@ -35,6 +35,7 @@
 ### [Slide title]
 - [bullet 1]
 - [bullet 2]
+- HIGHLIGHT: Research shows | [supporting evidence]
 
 ### [Video title]
 - VIDEO: https://www.youtube.com/watch?v=VIDEO_ID


### PR DESCRIPTION
## Summary
- allow `HIGHLIGHT:` bullets in Markdown to produce a callout card
- document highlight card usage in authoring spec and markdown template
- show a progress bar during PPTX export like the PDF workflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f8bc7a2883319cf61e4347774736