### PR TITLE
Fix reflection and quote slides in PPTX export

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,28 @@ function mdToOutline(md){
 
     if(/^###\s+/.test(L)){
       const h3 = L.replace(/^###\s+/, '').trim();
+
+      // Quote slide
+      if(/^quote$/i.test(h3)){
+        const line = (lines[i+1]||'').trim();
+        const cleaned = line.replace(/^[^\w"“]+/, '').replace(/\*/g, '').trim();
+        const parts = cleaned.split(/\s+[\-–—]\s+/);
+        const quote = parts[0] || '';
+        const by = parts[1] || '';
+        slides.push({ template:"06_quote", data:{ quote, by } });
+        i += 1;
+        continue;
+      }
+
+      // Reflective question slide
+      if(/reflect/i.test(h3)){
+        const line = (lines[i+1]||'').trim();
+        const quote = line.replace(/^[^\w"“]+/, '').replace(/\*/g, '').trim();
+        slides.push({ template:"06_quote", data:{ quote, by:"" } });
+        i += 1;
+        continue;
+      }
+
       const raw = getList(i+1);
       const next = getList.next;
       const data = { h1:h3, subtitle:"", bullets:[], icon:"", caption:"" };
@@ -903,6 +925,12 @@ function outlineToPptxSlides(outline){
           ], notes };
         }
         break;
+      case "06_quote":
+        slides[i] = { elements:[
+          { type:"text", text:d.quote || "", options:{ fontSize:32, italic:true, align:'center', y:2 } },
+          ...(d.by ? [{ type:"text", text:`— ${d.by}`, options:{ align:'center', y:3 } }] : [])
+        ], notes };
+        break;
       default:
         fallback.push(i);
         slides[i] = null;
@@ -913,20 +941,26 @@ function outlineToPptxSlides(outline){
 
 el.btnExportPPTX.onclick = async ()=>{
   try{
+    showProgress();
     const { slides, fallback } = outlineToPptxSlides(outline);
     let images = [];
     if(fallback.length){
       el.status.textContent = "⏳ Rendering slides…";
+      setProgress(50);
       ({ images } = await renderAllToImages({ lean: el.leanToggle.checked }));
       fallback.forEach(i=>{ slides[i] = { src: images[i], notes: outline.slides[i].data.notes || [] }; });
     }
     el.status.textContent = "⏳ Building PPTX…";
+    setProgress(90);
     const pptx = buildPptx(slides, { title: outline.meta.title });
     const name = (outline.meta.title || "Masterclass") + ".pptx";
     await pptx.writeFile({ fileName: name });
+    setProgress(100);
+    hideProgress();
     el.status.textContent = "✅ PPTX saved";
   }catch(err){
     console.error(err);
+    hideProgress();
     alert("PPTX export failed. Open the console for details.");
     el.status.textContent = "❌ PPTX export failed";
   }

--- a/src/export/pptxBuilder.js
+++ b/src/export/pptxBuilder.js
@@ -23,6 +23,9 @@ export function buildPptx(slides, meta = {}) {
             break;
           case 'text': {
             const text = el.text || '';
+            if (el.options && typeof el.options.y === 'number') {
+              y = el.options.y;
+            }
             slide.addText(text, { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
             const lines = text.split('\n').length;
             y += 0.6 * lines;

--- a/src/export/pptxBuilder.ts
+++ b/src/export/pptxBuilder.ts
@@ -46,6 +46,9 @@ export function buildPptx(slides: SlideModel[], meta: { title?: string } = {}): 
             break;
           case 'text': {
             const text = el.text || '';
+            if (el.options && typeof el.options.y === 'number') {
+              y = el.options.y;
+            }
             slide.addText(text, { x: 0.5, y, w: 9, fontSize: 18, ...(el.options || {}) });
             const lines = text.split('\n').length;
             y += 0.6 * lines;


### PR DESCRIPTION
## Summary
- Parse `Quote` and reflective headings into structured quote slides
- Render quote slides as editable text instead of images when exporting to PPTX
- Display progress bar during PPTX generation and allow custom text positioning

## Testing
- `node -e "require('./src/export/pptxBuilder.js'); console.log('loaded');"`
- `node <<'NODE'
const fs=require('fs');const vm=require('vm');
const html=fs.readFileSync('index.html','utf8');
const fnMatch=html.match(/function mdToOutline\(md\){[\s\S]*?return { meta:{ title:\"\" }, slides };\n}/);
const fnStr=fnMatch[0];
const ctx={};vm.createContext(ctx);vm.runInContext(fnStr,ctx);
const md=`### Reflective Question\n📝 *“When a student acts out, do I see defiance… or pain?”*\n\n### Quote\n💬 *“Children who have been hurt need consistency, predictability, and adults who don’t give up on them.”* – Bruce Perry`;
const outline=ctx.mdToOutline(md);
console.log(JSON.stringify(outline.slides));
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2084cf00883319020ee67e3720d1e