### PR TITLE
Add themed slide bars and footers to PPTX export

### DIFF
--- a/index.html
+++ b/index.html
@@ -990,6 +990,14 @@ function outlineToPptxSlides(outline){
         slides[i] = null;
     }
   });
+  const footerLeft = [outline.meta?.org, outline.meta?.presenter].filter(Boolean).join(' — ');
+  const footerRight = outline.meta?.date || '';
+  slides.forEach(sl=>{
+    if(sl && sl.elements){
+      if(footerLeft) sl.elements.push({ type:'footer', text:footerLeft, options:{ x:0.3, y:5.4, w:4.5 } });
+      if(footerRight) sl.elements.push({ type:'footer', text:footerRight, options:{ x:5.2, y:5.4, w:4.5, align:'right' } });
+    }
+  });
   return { slides, fallback };
 }
 

--- a/src/export/pptxBuilder.js
+++ b/src/export/pptxBuilder.js
@@ -26,8 +26,28 @@ export function buildPptx(slides, meta = {}) {
     pptx.coreProps = { title: meta.title };
   }
 
+  // Read theme colors from CSS variables if available
+  let brand = '#1e3a8a';
+  let accent = '#f97316';
+  if (typeof window !== 'undefined') {
+    const css = getComputedStyle(document.documentElement);
+    brand = css.getPropertyValue('--brand').trim() || brand;
+    accent = css.getPropertyValue('--accent').trim() || accent;
+  }
+
+  const titleBarH = 0.094;
+  const accentBarH = 0.031;
+  const footerBarH = 0.3125;
+
   slides.forEach(slideModel => {
     const slide = pptx.addSlide();
+
+    // Theme bars
+    slide.addShape(pptx.ShapeType.rect, { x: 0, y: 0, w: 10, h: titleBarH, fill: { color: brand }, line: { color: brand } });
+    slide.addShape(pptx.ShapeType.rect, { x: 0, y: titleBarH, w: 10, h: accentBarH, fill: { color: accent }, line: { color: accent } });
+    slide.addShape(pptx.ShapeType.rect, { x: 0, y: 5.625 - footerBarH - accentBarH, w: 10, h: accentBarH, fill: { color: accent }, line: { color: accent } });
+    slide.addShape(pptx.ShapeType.rect, { x: 0, y: 5.625 - footerBarH, w: 10, h: footerBarH, fill: { color: brand }, line: { color: brand } });
+
     if (slideModel.src) {
       // Slide represented as a pre-rendered image
       slide.addImage({ data: slideModel.src, x: 0, y: 0, w: 10, h: 5.625 });
@@ -58,6 +78,19 @@ export function buildPptx(slides, meta = {}) {
             const options = { path: el.src, x: 0.5, y, w: 4, h: 3, ...(el.options || {}) };
             slide.addImage(options);
             y += options.h + 0.5;
+            break;
+          }
+          case 'footer': {
+            const options = {
+              x: 0.3,
+              y: 5.625 - footerBarH + 0.05,
+              w: 9.4,
+              h: 0.2,
+              fontSize: 12,
+              color: 'FFFFFF',
+              ...(el.options || {})
+            };
+            slide.addText(el.text || '', options);
             break;
           }
         }


### PR DESCRIPTION
## Summary
- draw title, accent and footer color bars on each slide from the active HTML theme
- support a new `footer` slide element for placing text in the footer bar
- populate footer text from outline metadata for every slide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a218de3d9c8331952eedb7edf90dd1