### PR TITLE
Add AI master prompt template and update quickstart instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,15 +98,15 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
       </div>
     </header>
 
-    <div class="card mb-4">
-      <strong>Quickstart with AI</strong>
-      <ol class="p" style="margin:8px 0 0 18px">
-        <li>Download the <a href="masterclass_markdown_template.md" download>Markdown Template</a>.</li>
-        <li>Load it into your AI tool and prompt: <span class="small">"Research the topic and fill the template using markdown. Include image placeholders like <code>![](url)</code> and video links."</span></li>
-        <li>Paste the AI's markdown below and click <strong>Use Pasted Text</strong>.</li>
-        <li>Review the slides, then export to PPTX, ODP or PDF.</li>
-      </ol>
-    </div>
+  <div class="card mb-4">
+    <strong>Quickstart with AI</strong>
+    <ol class="p" style="margin:8px 0 0 18px">
+      <li>Download the <a href="masterclass_ai_master_prompt.md" download>AI Master Prompt Template</a> to craft your request or grab the <a href="masterclass_markdown_template.md" download>Markdown Template</a> for a blank outline.</li>
+      <li>Ask your AI to research any topic and fill the template using markdown. Include image placeholders like <code>![](url)</code> and video links.</li>
+      <li>Paste the AI's markdown below and click <strong>Use Pasted Text</strong>.</li>
+      <li>Review the slides, then export to PPTX, ODP or PDF.</li>
+    </ol>
+  </div>
 
     <div class="split">
       <!-- Left: import + meta + quick controls -->
@@ -118,6 +118,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
           <div class="toolbar mt-3">
             <a class="btn secondary" href="masterclass_ai_authoring_spec.txt" download>AI Authoring Spec</a>
             <a class="btn secondary" href="masterclass_markdown_template.md" download>Markdown Template</a>
+            <a class="btn secondary" href="masterclass_ai_master_prompt.md" download>AI Master Prompt Template</a>
           </div>
         </div>
         <div class="card">

--- a/masterclass_ai_master_prompt.md
+++ b/masterclass_ai_master_prompt.md
@@ -1,0 +1,75 @@
+# 🧠 Master Presentation Prompt Template
+Copy the entire block below into any AI chat, then fill in the placeholders.
+
+---
+
+title: "[Presentation Title]"
+presenter: "[Your Name]"
+org: "[Organization/School]"
+date: "[Date]"
+
+---
+
+## ✅ Instructions for the AI
+
+1. **Output Format**
+   - Deliver the ENTIRE presentation inside **one** markdown code block.
+   - Use a YAML-style header (as above).
+   - Each slide is an H2 or H3 heading (`##` / `###`).
+   - Do **not** label with “Slide 1, Slide 2.”
+   - If numbering helps you, put it in a `NOTE:` line; it must not appear on slides.
+
+2. **Content Expectations**
+   - Target: **[Number]** slides (minimum).
+   - Sections to cover (10 typical sections, modify as needed):
+     1. Introduction
+     2. Context & Data
+     3. [Key Principle 1]
+     4. Brain Science / Theory
+     5. Relationships / Culture
+     6. Classroom Strategies
+     7. SEL / Practice
+     8. Family & Community
+     9. Educator Wellness
+     10. Closing & Resources
+   - **Every bullet must be a full sentence** or short paragraph—no one-word bullets.
+   - Each slide should read like a mini teaching point and stand on its own.
+   - Include reflective questions, quotes, scenarios, or role-play prompts to boost engagement.
+
+3. **Media Integration**
+   - Embed media directly in slides (not at the end):
+     - **Images:** `![](https://picsum.photos/seed/[topic]/1000/450)` or real URLs provided.
+     - **Videos:** `VIDEO: [Title](https://www.youtube.com/watch?v=XXXXXX)`
+     - **Tables:** Inline markdown tables with clear labels.
+   - Mix text, images, video links, tables, quotes, and questions to avoid repetition.
+
+4. **Research & Credibility**
+   - Pull from trusted, current sources (CDC, CASEL, SAMHSA, etc.).
+   - Explain *why* each fact matters to the audience.
+   - Highlight location-specific data if relevant.
+
+5. **Tone & Style**
+   - Use professional yet approachable language.
+   - Avoid jargon unless defined.
+   - Use emojis sparingly to create emotional engagement (🌟, 💭, etc.).
+   - Insert pull quotes from experts to break up text.
+
+6. **Flow**
+   - Each section should progress logically:
+     - definition → data → quote → strategy → reflection → example.
+   - Include interactive elements (practice scenarios, role-plays, “What would you do?” questions).
+
+7. **Finishing Touches**
+   - End with key takeaways, quotes, and resource links.
+   - Check spelling, grammar, and consistent formatting before finalizing.
+
+## 🔧 Prompt to the AI
+
+Using the format and instructions above:
+
+"Create a [target number]-slide masterclass on **[Topic]** for **[Audience]**.
+Follow the YAML header and slide structure.
+Include full sentences, current research, quotes, reflective questions, and real or placeholder media links.
+Target sections: [list your 10 sections or modify].
+Deliver everything in one markdown code block."
+


### PR DESCRIPTION
## Summary
- Add downloadable AI Master Prompt Template with YAML header and slide guidelines.
- Update Quickstart instructions to link the template and note it works for any topic.
- Provide direct access to the new template in the Training Templates section.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a21c8b9cb88331b8a176e66ee89b35