### PR TITLE
Handle missing exporter modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,8 +220,13 @@ Subtitle
   </div>
 
 <script type="module">
-import { buildOdp } from './src/export/odpBuilder.js';
-import { buildPptx } from './src/export/pptxBuilder.js';
+let buildOdp, buildPptx;
+import('./src/export/odpBuilder.js')
+  .then(m => { buildOdp = m.buildOdp; })
+  .catch(err => console.warn('ODP builder failed to load', err));
+import('./src/export/pptxBuilder.js')
+  .then(m => { buildPptx = m.buildPptx; })
+  .catch(err => console.warn('PPTX builder failed to load', err));
 /*** --------------------- OUTLINE + PARSER --------------------- ***/
 let outline = { meta:{ title:"", presenter:"", org:"", date:"", theme:0 }, slides:[] };
 let idx = 0;
@@ -1016,6 +1021,10 @@ function outlineToPptxSlides(outline){
 }
 
 el.btnExportPPTX.onclick = async ()=>{
+  if(!buildPptx){
+    alert('PPTX exporter not available');
+    return;
+  }
   try{
     showProgress();
     const { slides, fallback } = outlineToPptxSlides(outline);
@@ -1045,6 +1054,10 @@ el.btnExportPPTX.onclick = async ()=>{
 
 /*** --------------------- EXPORT: ODP --------------------- ***/
 el.btnExportODP.onclick = async ()=>{
+  if(!buildOdp){
+    alert('ODP exporter not available');
+    return;
+  }
   try {
     showProgress();
     el.status.textContent = "⏳ Rendering slides…";


### PR DESCRIPTION
## Summary
- Load export helpers dynamically so missing modules don't block the app
- Warn and cancel if PPTX or ODP exporters are unavailable

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a224a13ca48331a876395e3d3ceb58