### PR TITLE
fix: make landing page text white

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,9 @@
 
 <!-- Minimal, modern styles (no build step) -->
 <style>
+/* Root color variables */
 :root{
-  --bg:#0b1220; --card:#0f172a; --muted:#94a3b8; --text:#e2e8f0;
+  --bg:#0b1220; --card:#0f172a; --muted:#94a3b8; --text:#ffffff;
   --brand:#1e3a8a; --accent:#f97316; --paper:#f5f7ff;
 }
 *{box-sizing:border-box}
@@ -26,7 +27,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 .grid{display:grid;gap:16px}
 .grid-2{grid-template-columns:420px 1fr}
 .input,textarea,select{background:#0b1325;color:var(--text);border:1px solid #1f2937;border-radius:10px;padding:10px;width:100%}
-.small{font-size:12px;color:var(--muted)}
+.small{font-size:12px;color:var(--text)}
 .toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
 .btn{background:var(--brand);border:none;color:white;padding:10px 14px;border-radius:10px;cursor:pointer;font-weight:600}
 .btn.secondary{background:#334155}
@@ -110,7 +111,7 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 
   <div class="card mb-4">
     <strong>Quickstart with AI</strong>
-    <ol class="p" style="margin:8px 0 0 18px">
+    <ol style="margin:8px 0 0 18px">
       <li>Download the <a href="masterclass_ai_master_prompt.md" download>AI Master Prompt Template</a> to craft your request or grab the <a href="masterclass_markdown_template.md" download>Markdown Template</a> for a blank outline.</li>
       <li>Ask your AI to research any topic and fill the template using markdown. Include image placeholders like <code>![](url)</code> and video links.</li>
       <li>Paste the AI's markdown below and click <strong>Use Pasted Text</strong>.</li>


### PR DESCRIPTION
## Summary
- set default text color to pure white and ensure small text uses same color
- remove slide theme class from Quickstart list so instructions display in white

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/masterclass/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a31e7e0a148331a905414117b3ca37