### PR TITLE
fix pptx export hanging at image fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -843,15 +843,22 @@ el.btnDownloadJson.onclick = ()=>{
 
 /*** --------------------- EXPORT: PPTX --------------------- ***/
 async function imgToDataURL(url){
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
   try{
-    const res = await fetch(url, { mode: "cors" });
+    const res = await fetch(url, { mode: "cors", signal: controller.signal });
+    if(!res.ok) return "";
     const blob = await res.blob();
-    return await new Promise((resolve)=>{
+    return await new Promise(resolve => {
       const r = new FileReader();
       r.onload = () => resolve(r.result);
       r.readAsDataURL(blob);
     });
-  }catch{ return ""; }
+  }catch{
+    return "";
+  }finally{
+    clearTimeout(timeout);
+  }
 }
 
 async function inlineSlideImages(container){


### PR DESCRIPTION
## Summary
- prevent PPTX export from stalling by aborting slow or unresponsive image requests
- ensure fetch timeouts are cleared and remote image errors safely ignored

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a320882a7c8331b884e05e3b040121