### PR TITLE
style: modernize card UI with gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <style>
 /* Root color variables */
 :root{
-  --bg:#0b1220; --card:#0f172a; --muted:#94a3b8; --text:#ffffff;
+  --bg:#0b1220; --muted:#94a3b8; --text:#ffffff;
   --brand:#1e3a8a; --accent:#f97316; --paper:#f5f7ff;
 }
 *{box-sizing:border-box}
@@ -23,7 +23,8 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 .container{max-width:1200px;margin:24px auto;padding:0 16px}
 .header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:16px}
 .h1{font-size:28px;font-weight:800}
-.card{background:var(--card);border-radius:16px;padding:16px;box-shadow:0 8px 30px rgba(0,0,0,.35)}
+.card{background:linear-gradient(135deg, var(--brand), var(--accent));color:var(--text);border-radius:16px;padding:16px;box-shadow:0 8px 30px rgba(0,0,0,.35)}
+.card .p{color:var(--text)}
 .grid{display:grid;gap:16px}
 .grid-2{grid-template-columns:420px 1fr}
 .input,textarea,select{background:#0b1325;color:var(--text);border:1px solid #1f2937;border-radius:10px;padding:10px;width:100%}
@@ -35,10 +36,10 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 .progress{width:120px;height:8px;background:#334155;border-radius:4px;overflow:hidden}
 .progress-bar{height:100%;width:0;background:var(--accent);transition:width .2s}
 .popup{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center}
-.popup-content{background:var(--card);padding:24px;border-radius:12px;text-align:center}
+.popup-content{background:linear-gradient(135deg, var(--brand), var(--accent));color:var(--text);padding:24px;border-radius:12px;text-align:center}
 .badge{background:#1e293b;padding:4px 8px;border-radius:999px;color:var(--text);font-size:12px}
 .split{display:grid;grid-template-columns:420px 1fr;gap:16px}
-.preview{background:white;border-radius:12px;overflow:auto;height:560px;padding:8px}
+.preview{background:white;border-radius:12px;overflow:auto;height:560px;padding:8px;color:#1e293b}
 .slide-list{list-style:none;padding:0;margin:8px 0;max-height:160px;overflow:auto}
 .slide-list li{padding:4px 8px;border-radius:6px;margin-bottom:4px;background:#1e293b;cursor:grab}
 .slide-list li.active{background:var(--brand)}


### PR DESCRIPTION
## Summary
- Replace dark card backgrounds with bright brand-to-accent gradients and force white text
- Apply gradient styling to popup cards and adjust preview text color for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be0019cf288331b46cbea6f3bd3335