### PR TITLE
fix: replace binary logo assets with inline svg

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>Masterclass — Research → Slides → PPTX/ODP/PDF</title>
 
+<!-- Icons (embedded SVG to avoid binary assets) -->
+<link rel="icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn46TPC90ZXh0Pjwvc3ZnPg=="/>
+<link rel="apple-touch-icon" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn46TPC90ZXh0Pjwvc3ZnPg=="/>
+<meta property="og:image" content="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48dGV4dCB5PScuOWVtJyBmb250LXNpemU9JzkwJz7wn46TPC90ZXh0Pjwvc3ZnPg=="/>
+
 <!-- Fonts -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- embed SVG data URIs for favicon and sharing image
- remove generated binary icon files from repository

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be22ccd8ec8331967721cc6ee53f69